### PR TITLE
Fix -R and stdin, out, err

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -11,7 +11,7 @@ const DENO_FLAGS = [
   "--allow-run",
   "--allow-write=",
   "--reload",
-  "-R",
+  "-r",
   "--lock=",
   "--importmap=",
   "--unstable",

--- a/mod.ts
+++ b/mod.ts
@@ -33,8 +33,8 @@ export async function dpx(
   const filePath = await getEntryFile(packageName);
   return Deno.run({
     cmd: ["deno", "run", ...flags, filePath, ...args],
-    stdout: "inherit",
-    stderr: "inherit",
-    stdin: "inherit",
+    stdout: "null",
+    stderr: "null",
+    stdin: "null",
   }).status();
 }


### PR DESCRIPTION
- Fix deno arg -R to -r
- Set stdin, out, err, to null to avoid leak.